### PR TITLE
chore: update dependency for @telicent-oss/rdfservice to use local li…

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,9 @@ importers:
 
   packages/OntologyService:
     dependencies:
-      '@telicent-io/rdfservice':
+      '@telicent-oss/rdfservice':
         specifier: '*'
-        version: 0.0.14-rc41
+        version: link:../RdfService
       zod:
         specifier: ^3.22.4
         version: 3.22.4
@@ -2557,14 +2557,6 @@ packages:
     resolution: {integrity: sha512-myfUej5naTBWnqOCc/MdVOLVjXUXtIA+NpDrDBKJtLLg2shUjBu3cZmB/85RyitKc55+lUUyl7oRfLOvkr2hsw==}
     dev: true
 
-  /@telicent-io/rdfservice@0.0.14-rc41:
-    resolution: {integrity: sha512-dAV+00a+XFuSgIFPrWbVnNxBR9aT/wcIrKT69T9L1y7lhkEnY45BFMUn8z84NN+cwcrx/JDbEn1mHXQQWGD+5Q==, tarball: https://npm.pkg.github.com/download/@telicent-io/rdfservice/0.0.14-rc41/b15be091e416ef128971c795722fe87c610ced9d}
-    dependencies:
-      global: 4.4.0
-      pnpm: 8.15.1
-      zod: 3.22.4
-    dev: false
-
   /@tootallnate/once@2.0.0:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
@@ -3299,13 +3291,12 @@ packages:
     dev: true
 
   /chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==, tarball: https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz}
+    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
     dev: true
-
 
   /chalk@5.3.0:
     resolution: {integrity: sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==}


### PR DESCRIPTION
…nk instead of versioned package

The dependency for `@telicent-oss/rdfservice` in the `packages/OntologyService` has been updated to use a local link `link:../RdfService` instead of a specific version `0.0.14-rc41`. This change allows for easier development and testing of the `OntologyService` package with the latest changes in the `RdfService` package.