### PR TITLE
chore(release): 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### 0.0.2 (2024-03-01)
+
+
+### Features
+
+* initial commit ([24485f3](https://github.com/Telicent-oss/rdf-libraries/commit/24485f3dd799664850813a7dfcc31d6043d8bf47))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rdf-libraries",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Simple client-side lib for working with ontologies",
   "scripts": {
     "preinstall": "node ./scripts/enforcePnpm.js",


### PR DESCRIPTION
Generate change log (mainly to trigger the **npm publish** workflow):
```sh
$ npx standard-version

✔ bumping version in package.json from 0.0.1 to 0.0.2
✔ created CHANGELOG.md
✔ outputting changes to CHANGELOG.md
✔ committing package.json and CHANGELOG.md
✔ tagging release v0.0.2
```