### PR TITLE
fix(package.json): include file extension in file definition

### DIFF
--- a/packages/OntologyService/package.json
+++ b/packages/OntologyService/package.json
@@ -14,7 +14,7 @@
       "require": "./dist/ontologyservice.umd.js"
     }
   },
-  "types": "./dist/types",
+  "types": "./dist/types.d.ts",
   "scripts": {
     "generate-docs": "./node_modules/.bin/typedoc --out dist/docs .",
     "open-docs": "open ./dist/docs/index.html",

--- a/packages/OntologyService/package.json
+++ b/packages/OntologyService/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telicent-oss/ontologyservice",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": false,
   "description": "Simple client-side library for working with RDF ontologies. Includes basic CRUD abilities and functions to help you navigate an ontology hierarchy.",
   "main": "./dist/ontologyservice.mjs",
@@ -11,7 +11,8 @@
   "exports": {
     ".": {
       "import": "./dist/ontologyservice.mjs",
-      "require": "./dist/ontologyservice.umd.js"
+      "require": "./dist/ontologyservice.umd.js",
+      "types": "./dist/types.d.ts"
     }
   },
   "types": "./dist/types.d.ts",

--- a/packages/RdfService/package.json
+++ b/packages/RdfService/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telicent-oss/rdfservice",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": false,
   "description": "RdfService is a helper library that abstracts away the complexity of interacting with RDF triplestores, providing basic CRUD abilities.",
   "main": "./dist/rdfservice.mjs",
@@ -11,7 +11,8 @@
   "exports": {
     ".": {
       "import": "./dist/rdfservice.mjs",
-      "require": "./dist/rdfservice.umd.js"
+      "require": "./dist/rdfservice.umd.js",
+      "types": "./dist/types.d.ts"
     }
   },
   "types": "./dist/types.d.ts",

--- a/packages/RdfService/package.json
+++ b/packages/RdfService/package.json
@@ -14,7 +14,7 @@
       "require": "./dist/rdfservice.umd.js"
     }
   },
-  "types": "./dist/types",
+  "types": "./dist/types.d.ts",
   "scripts": {
     "generate-docs": "./node_modules/.bin/typedoc --out dist/docs .",
     "open-docs": "open ./dist/docs/index.html",


### PR DESCRIPTION
when importing these files currently the IDE complains of being unable to find the type definition file. Documentation suggests the file extension should be explicitely stated