### PR TITLE
fix(RdfService): wrap full uri in angle bracket

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rdf-libraries",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Simple client-side lib for working with ontologies",
   "scripts": {
     "preinstall": "node ./scripts/enforcePnpm.js",

--- a/packages/OntologyService/package.json
+++ b/packages/OntologyService/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telicent-oss/ontologyservice",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": false,
   "description": "Simple client-side library for working with RDF ontologies. Includes basic CRUD abilities and functions to help you navigate an ontology hierarchy.",
   "main": "./dist/ontologyservice.mjs",

--- a/packages/RdfService/index.ts
+++ b/packages/RdfService/index.ts
@@ -240,13 +240,13 @@ export default class RdfService {
    * Shortens a URI to its prefixed equivalent. If no prefix is found, the full URI is returned
    *
    * @param uri - the URI represented by the prefix
-   * @returns the prefix that matches the URI, if not found, the URI is returned 
+   * @returns the prefix that matches the URI, if not found, the URI is returned wrapped in angle brackets
   */
   shorten(uri: string) {
     const keys = Object.keys(this.prefixDict)
 
     const result = keys.find(key => uri.includes(this.prefixDict[key]));
-    return result ? uri.replace(this.prefixDict[result], result) : uri;
+    return result ? uri.replace(this.prefixDict[result], result) : `<${uri}>`;
   }
 
   /**

--- a/packages/RdfService/package.json
+++ b/packages/RdfService/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telicent-oss/rdfservice",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": false,
   "description": "RdfService is a helper library that abstracts away the complexity of interacting with RDF triplestores, providing basic CRUD abilities.",
   "main": "./dist/rdfservice.mjs",


### PR DESCRIPTION
When a uri doesn't match any known prefixes, the uri should return wrapped in angle brackets so that it is valid ttl

@AlecsMissangu  @dptelicent will this change affect any of your apps in an adverse way?