### PR TITLE
ci: update pnpm action to v4

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -26,10 +26,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 8
+          version: 9
           run_install: false
 
       - uses: nrwl/nx-set-shas@v3

--- a/.github/workflows/publish-nx.yml
+++ b/.github/workflows/publish-nx.yml
@@ -24,9 +24,9 @@ jobs:
           scope: 'telicent-oss'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
       - run: pnpm install
       - run: pnpm nx run-many -t test,build -p @telicent-oss/rdfservice @telicent-oss/ontologyservice 
       - run: cd ./packages/RdfService && npm publish --access public --provenance

--- a/.github/workflows/publish-rc.yml
+++ b/.github/workflows/publish-rc.yml
@@ -26,10 +26,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 8
+          version: 9
           run_install: false
 
       - uses: nrwl/nx-set-shas@v3

--- a/.github/workflows/temp-workflow-publish.yml
+++ b/.github/workflows/temp-workflow-publish.yml
@@ -26,10 +26,10 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 8
+          version: 9
           run_install: false
 
       - uses: nrwl/nx-set-shas@v3

--- a/.github/workflows/test-release-nx.yml
+++ b/.github/workflows/test-release-nx.yml
@@ -19,10 +19,10 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
         with:
-          version: 8
+          version: 9
           run_install: false
 
       - uses: nrwl/nx-set-shas@v3

--- a/.github/workflows/update-docs.yml
+++ b/.github/workflows/update-docs.yml
@@ -17,9 +17,9 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         with:
-          version: 8
+          version: 9
       - run: pnpm install
       - run: yarn generate-docs
       - run: |


### PR DESCRIPTION
update pnpm to v9 and use latest action

Workflows had failed to build. On further investigation, the issues on the repo suggest to update the action to the v4