### PR TITLE
feat(CatalogService): [TELFE-1] publish-nx-catalog-service

### DIFF
--- a/.github/workflows/publish-nx-catalog-service.yml
+++ b/.github/workflows/publish-nx-catalog-service.yml
@@ -1,0 +1,36 @@
+name: Publish NX
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - CHANGELOG.md
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org/'
+          scope: 'telicent-oss'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+      - uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - run: pnpm install
+      # TODO convert tests to Test Containers
+      # - run: pnpm nx run-many -t test,build -p @telicent-oss/rdfservice @telicent-oss/ontologyservice 
+      - run: cd ./packages/CatalogService && npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_REGISTRY_TOKEN }}
+          NPM_CONFIG_PROVENANCE: true


### PR DESCRIPTION
Ticket: 
https://telicent.atlassian.net/browse/TELFE-1
https://telicent.atlassian.net/browse/TELFE-538 (deployments)

I believe:
1. main branch is broken; 
2. C.I. seems to work due to cached node_modules.

I need a dev build (for SBOMs) for a dev build [here](https://github.com/telicent-oss/rdf-libraries/pull/82)

Workflows can only be triggered with workflows on `main`

