### PR TITLE
fix(rdfservice): bump to v1.0.0

### DIFF
--- a/packages/CatalogService/package.json
+++ b/packages/CatalogService/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telicent-oss/catalogservice",
-  "version": "0.4.0-TELFE-1098.0",
+  "version": "1.0.0",
   "// TEMP private": "needs merge to main",
   "private": false,
   "description": "Simple client-side library for working with DCAT data.",
@@ -47,7 +47,7 @@
     "url": "git+https://github.com/telicent-oss/rdf-libraries.git"
   },
   "dependencies": {
-    "@telicent-oss/rdfservice": "0.3.0-TELFE-1098.0",
+    "@telicent-oss/rdfservice": "1.0.0",
     "@types/cors": "2.8.17",
     "cors": "2.8.5",
     "express": "4.19.2",

--- a/packages/OntologyService/package.json
+++ b/packages/OntologyService/package.json
@@ -37,7 +37,7 @@
     "url": "git+https://github.com/telicent-oss/rdf-libraries.git"
   },
   "dependencies": {
-    "@telicent-oss/rdfservice": "0.2.0",
+    "@telicent-oss/rdfservice": "1.0.0",
     "@types/lodash": "^4.17.13",
     "lodash": "^4.17.21",
     "zod": "^3.23.8"

--- a/packages/RdfService/package.json
+++ b/packages/RdfService/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telicent-oss/rdfservice",
-  "version": "0.3.0-TELFE-1098.0",
+  "version": "1.0.0",
   "private": false,
   "description": "RdfService is a helper library that abstracts away the complexity of interacting with RDF triplestores, providing basic CRUD abilities.",
   "main": "./dist/rdfservice.mjs",

--- a/packages/ies-service/package.json
+++ b/packages/ies-service/package.json
@@ -43,7 +43,7 @@
     "url": "git+https://github.com/telicent-oss/rdf-libraries.git"
   },
   "dependencies": {
-    "@telicent-oss/rdfservice": "0.2.0",
+    "@telicent-oss/rdfservice": "1.0.0",
     "snapshot-diff": "0.10.0",
     "zod": "^3.22.4"
   },

--- a/packages/ontology-icon-react-lib/package.json
+++ b/packages/ontology-icon-react-lib/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@telicent-oss/ds": "0.13.0",
     "@telicent-oss/ontology-icon-lib": "^0.5.0-TELFE-1175.3",
-    "@telicent-oss/rdfservice": "0.2.0",
+    "@telicent-oss/rdfservice": "1.0.0",
     "@telicent-oss/react-lib": "^0.5.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2840,14 +2840,6 @@
     global "^4.4.0"
     zod "^3.22.4"
 
-"@telicent-oss/rdfservice@0.2.0":
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/@telicent-oss/rdfservice/-/rdfservice-0.2.0.tgz#ebcee9da977a8dd25336b183e90235232c388aa3"
-  integrity sha512-lx5ADEPW1/B9kw06mBfMDQTEmziD5k5iYS5ZLhbYELEguZFPwFwnUuYUKXBsaNNpGVaVb0BoE31gzG7k+vIjSg==
-  dependencies:
-    global "^4.4.0"
-    zod "^3.22.4"
-
 "@testing-library/dom@^9.0.0":
   version "9.3.4"
   resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-9.3.4.tgz#50696ec28376926fec0a1bf87d9dbac5e27f60ce"


### PR DESCRIPTION
For network wrrors, the "TELFE-1098" prerelease versions changed error handling to throw full response - instead of just statusText