### PR TITLE
fix: vite config

### DIFF
--- a/packages/ontology-icon-react-lib/vite.config.ts
+++ b/packages/ontology-icon-react-lib/vite.config.ts
@@ -3,6 +3,10 @@ import { defineConfig, PluginOption } from "vite";
 import dts from "vite-plugin-dts";
 import path from "path";
 import fs from "fs";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
 const packageJson = JSON.parse(
   fs.readFileSync(path.resolve(__dirname, "package.json"), "utf-8")


### PR DESCRIPTION
Because package.json is a module you lose access to __dirname.