### PR TITLE
fix(handleCallback): [TELFE-1477] 400s reference error

### DIFF
--- a/packages/fe-auth-lib/package.json
+++ b/packages/fe-auth-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telicent-oss/fe-auth-lib",
-  "version": "1.0.2",
+  "version": "1.0.2-TELFE-1477.0",
   "private": false,
   "license": "Apache-2.0",
   "description": "OAuth2 client library for Telicent Authentication Server",

--- a/packages/fe-auth-lib/package.json
+++ b/packages/fe-auth-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@telicent-oss/fe-auth-lib",
-  "version": "1.0.2-TELFE-1477.0",
+  "version": "1.0.2",
   "private": false,
   "license": "Apache-2.0",
   "description": "OAuth2 client library for Telicent Authentication Server",

--- a/packages/fe-auth-lib/src/__tests__/callback.failures.test.ts
+++ b/packages/fe-auth-lib/src/__tests__/callback.failures.test.ts
@@ -227,7 +227,11 @@ describe("failure path - handleCallback failure modes", () => {
     );
     globalThis.fetch = fetchMock;
 
-    await client.handleCallback({ code: "CODE_1", state: "STATE_1" });
+    await expect(
+      client.handleCallback({ code: "CODE_1", state: "STATE_1" })
+    ).rejects.toThrow(
+      "access_denied redirecting to http://auth.telicent.localhost/account-inactive"
+    );
 
     expect({
       href: window.location.href,
@@ -235,7 +239,7 @@ describe("failure path - handleCallback failure modes", () => {
       oauthVerifier: sessionStorage.getItem("oauth_code_verifier"),
     }).toMatchInlineSnapshot(`
       {
-        "href": "http://auth.telicent.localhost/oauth2/authorize/account-inactive",
+        "href": "http://auth.telicent.localhost/account-inactive",
         "oauthState": null,
         "oauthVerifier": null,
       }


### PR DESCRIPTION
Ticket: https://telicent.atlassian.net/browse/TELFE-1477

### Goal

- Fix when /oauth2/token returns { error: "access_denied" } with status 400, client.handleCallback() throws

> ReferenceError: Cannot access 'errorMessage' before initialization. The access_denied 

### Work Completed

- Fix syntax error + tests

### Testing Method

- Unit tests and tested locally

### Next steps

- Once confirmed as working - rollout to all apps