### PR TITLE
fix(fe-auth-lib): include PATCH in same-domain CSRF header allowlist

### DIFF
--- a/packages/fe-auth-lib/src/AuthServerOAuth2Client.js
+++ b/packages/fe-auth-lib/src/AuthServerOAuth2Client.js
@@ -713,7 +713,7 @@ class AuthServerOAuth2Client {
       // Same-domain: Add CSRF token for state-changing requests
       if (
         options.method &&
-        ["POST", "PUT", "DELETE"].includes(options.method.toUpperCase())
+        ["POST", "PUT", "DELETE", "PATCH"].includes(options.method.toUpperCase())
       ) {
         const csrfToken = this.getCsrfToken();
         if (csrfToken) {
@@ -778,7 +778,7 @@ class AuthServerOAuth2Client {
       // Same-domain: Add CSRF token for state-changing requests
       if (
         options.method &&
-        ["POST", "PUT", "DELETE"].includes(options.method.toUpperCase())
+        ["POST", "PUT", "DELETE", "PATCH"].includes(options.method.toUpperCase())
       ) {
         const csrfToken = this.getCsrfToken();
         if (csrfToken) {

--- a/packages/fe-auth-lib/src/__tests__/request-helpers.success.test.ts
+++ b/packages/fe-auth-lib/src/__tests__/request-helpers.success.test.ts
@@ -86,6 +86,29 @@ describe("happy path - request helpers add auth headers", () => {
     `);
   });
 
+  it("adds CSRF token for same-domain PATCH requests", async () => {
+    const client = new AuthServerOAuth2Client(createConfig());
+    setCookies("XSRF-TOKEN=csrf-patch");
+    const fetchMock = jest.fn().mockResolvedValue(createFetchResponse({}));
+    globalThis.fetch = fetchMock;
+
+    await client.makeAuthenticatedRequest(
+      "http://auth.telicent.localhost/data",
+      { method: "PATCH" }
+    );
+
+    expect({
+      headers: fetchMock.mock.calls[0][1]?.headers,
+    }).toMatchInlineSnapshot(`
+      {
+        "headers": {
+          "Accept": "application/json",
+          "X-XSRF-TOKEN": "csrf-patch",
+        },
+      }
+    `);
+  });
+
   it("prepares request headers for cross-domain and same-domain", () => {
     const crossDomainClient = new AuthServerOAuth2Client(
       createConfig({ authServerUrl: "https://auth.telicent.io" })


### PR DESCRIPTION
## Summary
- `makeAuthenticatedRequest` and `beforeRequest` in `AuthServerOAuth2Client.js` gated the `X-XSRF-TOKEN` header on `["POST", "PUT", "DELETE"]`, so same-domain `PATCH` requests went out without CSRF and were rejected (typically 403) by CSRF-enforcing backends.
- Added `PATCH` to both allowlists (RFC 5789 — PATCH is state-changing).
- Added a regression test covering `method: "PATCH"` mirroring the existing POST case.

## Context
This was masked upstream: `@telicent-oss/ds`'s `withSessionHandling` was passing Axios's lowercased `config.method` straight to `fetch`, which per WHATWG Fetch does not normalise `patch` → `PATCH`, so Envoy rejected with 400 before CSRF ran. Once the DS-side uppercasing lands, PATCH requests reach backends and this CSRF gap becomes the next wall (real-world impact: `catalogSI PATCH /v1/datasets/{id}`).

## Test plan
- [x] `npx jest request-helpers.success` — 5/5 passing, new PATCH case included
- [ ] Consumers (including `@telicent-oss/ds`) pick up on next dep bump after patch release