### PR TITLE
fix(ci): release-config check ignores dirs without package.json

### DIFF
--- a/scripts/check-release-please-config/index.js
+++ b/scripts/check-release-please-config/index.js
@@ -20,9 +20,15 @@ const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
 // Extract package paths from the config
 const configuredPackages = Object.keys(config.packages);
 
-// Read directories under ./packages/
+// Read package directories under ./packages/ (a directory is only a package
+// if it contains a package.json; skips leftover dirs like stray node_modules
+// or build output that aren't publishable packages).
 const directories = fs.readdirSync(packagesDir)
-  .filter(item => fs.statSync(path.join(packagesDir, item)).isDirectory())
+  .filter(item => {
+    const full = path.join(packagesDir, item);
+    return fs.statSync(full).isDirectory()
+      && fs.existsSync(path.join(full, 'package.json'));
+  })
   .map(dir => `packages/${dir}/`);
 
 // Compare directories with configured packages


### PR DESCRIPTION
✅  **AI-generated: I reviewed line-by-line review**

Ticket: None. Small DX issue

### Goal

Your push no longer fails on a leftover package directory left behind after switching branches. A real package missing from `release-please-config.json` still fails.

<details>
<summary>Why it failed before</summary>

The check listed every subdirectory of `packages/` and failed if one was missing from `release-please-config.json`. Author a new package on one branch, then switch to a branch without it: its `node_modules`/`dist` stay on disk with no `package.json`, so the check saw a package that is not one and blocked the push. The fix counts a directory as a package only if it has a `package.json`.

</details>

### Testing Method

Ran the check against a leftover directory with no `package.json` (passes) and a directory with a `package.json` missing from the config (still fails).
