### PR TITLE
ci(release-please): seed manifest so release PRs actually open

### DIFF
--- a/.github/.release-please-manifest.json
+++ b/.github/.release-please-manifest.json
@@ -1,1 +1,14 @@
-{}
+{
+  "packages/RdfService/": "1.0.2",
+  "packages/OntologyService/": "1.0.4",
+  "packages/CatalogService/": "2.0.0",
+  "packages/ies-service/": "1.0.1",
+  "packages/ontology-icon-lib/": "1.0.3",
+  "packages/ontology-icon-react-lib/": "2.0.0",
+  "packages/react-lib/": "0.7.0",
+  "packages/rdf-write-lib/": "1.0.2",
+  "packages/sparql-lib/": "1.0.0",
+  "packages/dev-dependencies-lib/": "0.0.2",
+  "packages/mui-icons-material/": "1.0.0",
+  "packages/fe-auth-lib/": "1.0.3"
+}

--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "// examples": "https://github.com/googleapis/release-please/tree/main/test/fixtures/manifest/config",
   "bootstrap-sha": "24485f3dd799664850813a7dfcc31d6043d8bf47",
+  "last-release-sha": "3e91f0e25451db9a469ea198fd5baae10ce2bc37",
   "packages": {
     "packages/RdfService/": {
       "labels": [


### PR DESCRIPTION
📣 **AI-generated: Requires line-by-line review**

### Goal

Make release-please actually open release PRs. Right now it runs green on every merge to main but creates nothing.

Cause: `.github/.release-please-manifest.json` was `{}`. In manifest mode release-please reads each package's last-released version from that file; with no baseline it proposes no bumps. This seeds it with the 12 configured packages' current versions.

`last-release-sha` is set to the current main HEAD (`3e91f0e`). Without it, release-please would fall back to `bootstrap-sha` (the initial commit) and replay all 559 commits of history into one giant, wrong first release PR. With it, the first release PR covers only commits merged after this PR.

### Effect after merge

- Every future `fix:`/`feat:` merged to main opens or updates a release PR that bumps the affected package and writes its CHANGELOG
- The first release PR appears on the next qualifying merge, not from history
- Nothing publishes until a release PR is merged; the manual version-bump path still works alongside it

<details>
<summary>Seeded versions</summary>

```
packages/RdfService/              1.0.2
packages/OntologyService/         1.0.4
packages/CatalogService/          2.0.0
packages/ies-service/             1.0.1
packages/ontology-icon-lib/       1.0.3
packages/ontology-icon-react-lib/ 2.0.0
packages/react-lib/               0.7.0
packages/rdf-write-lib/           1.0.2
packages/sparql-lib/              1.0.0
packages/dev-dependencies-lib/    0.0.2
packages/mui-icons-material/      1.0.0
packages/fe-auth-lib/             1.0.3
```

Each value is the current `package.json` version on main. `fe-auth-lib` is `1.0.3` here; PR #360 bumps it to `1.0.4`. If #360 merges first, update this entry to `1.0.4` so the manifest matches `package.json`.

</details>

### Testing Method

Validated both JSON files parse and the manifest's 12 keys exactly match the config's package keys.
