### PR TITLE
fix(ci): sync yarn.lock so publish stops aborting on a dirty tree

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3420,6 +3420,13 @@
     svg-path-parser "^1.1.0"
     zod "^3.21.4"
 
+"@telicent-oss/fe-auth-lib@1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@telicent-oss/fe-auth-lib/-/fe-auth-lib-1.0.3.tgz#c64d9a06ee45fc433aa8b89a0223523b952d157d"
+  integrity sha512-+PGiNhTAKNaTRLXOVlkRP6iycA7m6ZmhR9D5c271mUGPA8bD3lLlq0+WAoTW+GoRVXWKWcveEHdKtvw1ocxVOA==
+  dependencies:
+    zod "^3.23.8"
+
 "@telicent-oss/telicent-frontend-cli@^1.5.0":
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@telicent-oss/telicent-frontend-cli/-/telicent-frontend-cli-1.5.0.tgz#afb2a6938af7e5a02aac151b82a30751b0135b37"


### PR DESCRIPTION
✅ **AI-generated: Requires line-by-line review**

### Goal

Unblocks publishing. The publish job aborts on a dirty tree: `yarn install` rewrites `yarn.lock`, then `publish:ci.sh` sees `M yarn.lock` and stops before `lerna publish from-package`. Committing the drift makes install a no-op so publish can run.

The whole diff is one transitive entry (+7 lines). `@telicent-oss/ds@3.0.0` depends on `@telicent-oss/fe-auth-lib@1.0.3`, so Yarn records that published tarball. It resolves from the registry, not the local `packages/fe-auth-lib` workspace (now 1.0.4), because ds is a published dependency pinning 1.0.3. Expected, not a mistake.

### Testing Method

`git diff origin/main` is `yarn.lock` only, +7 lines. The next publish run on merge confirms `yarn install` is a no-op and 1.0.4 ships.
