### PR TITLE
test: pin fuseki test image to 4.7.0

### DIFF
--- a/packages/OntologyService/__tests__/OntologyService.jena_integration.test.ts
+++ b/packages/OntologyService/__tests__/OntologyService.jena_integration.test.ts
@@ -32,7 +32,7 @@ function delay(ms: number) {
 describe("OntologyService - Integration Test with Fuseki - Create Data", () => {
   let fuseki: StartedTestContainer;
   beforeAll(async () => {
-    fuseki = await new GenericContainer("atomgraph/fuseki")
+    fuseki = await new GenericContainer("atomgraph/fuseki:4.7.0")
       .withExposedPorts(3030)
       .withCommand(["--mem", "ontology_test/"])
       .withWaitStrategy(Wait.forAll(

--- a/packages/RdfService/__tests__/RdfService.test.ts
+++ b/packages/RdfService/__tests__/RdfService.test.ts
@@ -23,7 +23,7 @@ function delays(ms: number) {
 describe("RdfService", () => {
   let fuseki: StartedTestContainer;
   beforeAll(async () => {
-    fuseki = await new GenericContainer("atomgraph/fuseki")
+    fuseki = await new GenericContainer("atomgraph/fuseki:4.7.0")
       .withExposedPorts(3030)
       .withCommand(["--mem", "rdf_test/"])
       .withWaitStrategy(Wait.forAll(


### PR DESCRIPTION
✅  **AI-generated: Reviewed line-by-line**

Ticket: none

### Goal

Green CI for the RdfService test suite.

### Work Completed

- Pin the Fuseki test container to `atomgraph/fuseki:4.7.0` in both integration tests that use it: RdfService and OntologyService

### Design Testing

No UI change.

- [-] Design approval areas not applicable

### Testing Method

Ran both suites locally against the pinned image: all tests pass.

### Engineering Notes

`atomgraph/fuseki:latest` moved to Fuseki 6.1.0 on 2026-06-04. That version changed the startup banner, so `Wait.forLogMessage(/Start Fuseki (http=NNNN)/)` never matched and `.start()` ran to the 60s `beforeAll` timeout. `4.7.0` is the version `:latest` pointed at before that push and still prints the awaited banner.
